### PR TITLE
Domain spb.ru is false positive

### DIFF
--- a/domains.list
+++ b/domains.list
@@ -787,6 +787,7 @@ someonewhocares.org
 spaces.live.com
 spapps.co
 spapps.spotify.edgekey.net
+spb.ru
 spclient.wg.spotify.com
 spiceworks.com
 sport.onet.pl


### PR DESCRIPTION
Introduction of:

spb.ru

It is second level geodomain for Saint-Petersburg city (spb) in
Russian Federation. There are many government and other legal
third-level subdomains.

See more: https://en.wikipedia.org/wiki/.ru