### PR TITLE
Introduction of `thumbs2.imgbox.com`

### DIFF
--- a/domains.list
+++ b/domains.list
@@ -893,6 +893,7 @@ thenextweb.com
 thepiratebay.org
 thetvdb.com
 theverge.com
+thumbs2.imgbox.com
 time.com
 tinyurl.com
 title.auth.xboxlive.com


### PR DESCRIPTION
Introduction of `thumbs2.imgbox.com`.
  
 * This patch fix `imgbox.com` image thumbnails.
 * e.g. https://thumbs2.imgbox.com/f7/c1/4YwNCH01_t.jpeg