### PR TITLE
Fixed typo with TDL vs TLD

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -102,7 +102,7 @@ regex which follows the marker.
 """""""""""
 
 The :code:`RZD` marker will tell the system to explicitly check for the given
-string plus all possible TDL.
+string plus all possible TLD.
 
 Anti whitelist
 --------------


### PR DESCRIPTION
TLD is Top Level Domain while TDL is nothing

Fix of readme